### PR TITLE
Update digitalearth to 0.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,52 +1,62 @@
 {% set name = "digitalearth" %}
-{% set version = "0.1.11" %}
+{% set version = "0.2.0" %}
+{% set python_min = "3.11" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/MAfarrag/Digital-Earth/archive/{{ version }}.tar.gz
-  sha256: a557c01c02b55fb3d9428e79b6fb3b7b6d3136895817f75fff112bb0a5bccce3
+  url: https://github.com/serapeum-org/Digital-Earth/archive/{{ version }}.tar.gz
+  sha256: 31e2a9845a5afc3bae7e1b6d1888c71827ee5b6fe83fd946097b155603dd34ad
 
 build:
-  number: 1
+  number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python {{ python_min }}
-    - pip >=22.3.1
+    - pip
+    - setuptools >=80.0.0
+    - wheel
   run:
-    - python >={{ python_min }},<3.11
-    - pip >=22.3.1
-    - numpy >=1.24.1
-    - gdal >=3.5.3
-    - geopandas >=0.12.2
-    - geoplot >=0.5.1
-    - cleopatra >=0.2.7
-    - pyramids >=0.3.2
-    - loguru >=0.6.0
-
+    - python >={{ python_min }}
+    - numpy >=2.0.0
+    - geopandas >=1.1.3
+    - cleopatra >=0.15.0
+    - pyramids >=0.27.0
+    - loguru >=0.7.3
+    - pyyaml >=6.0
 
 test:
   requires:
     - python {{ python_min }}
+    - pip
   imports:
     - digitalearth
+    - digitalearth.scene
+    - digitalearth.autostyle
+  commands:
+    - pip check
+    - digitalearth --help
 
 about:
-  home: https://github.com/MAfarrag/Digital-Earth
-  license:  GPL-3.0-only
+  home: https://github.com/serapeum-org/Digital-Earth
+  license: GPL-3.0-only
   license_family: GPL3
   license_file: LICENSE.md
-  summary: Geo-spatial visualization package
+  summary: Geospatial visualization package for rasters and vector data
   description: |
-    Geo-spatial visualization package.
-  dev_url: https://github.com/MAfarrag/Digital-Earth
-  doc_url: https://digitalearth.readthedocs.io/
-  doc_source_url: https://github.com/MAfarrag/Digital-Earth/main/README.md
+    digitalearth is a geospatial visualization package: it plots rasters and
+    vector data by wiring pyramids (GIS) data into cleopatra (matplotlib)
+    glyphs. It provides maps and raster fields, point/cell and vector-field
+    plots, unstructured meshes, composites, ensemble/temporal series,
+    projected and globe maps, animations, charts, automatic field styling,
+    and a batch / HTML-gallery / CLI delivery tier.
+  dev_url: https://github.com/serapeum-org/Digital-Earth
+  doc_url: https://serapeum-org.github.io/Digital-Earth
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Updates the recipe to **digitalearth 0.2.0** and realigns it with the upstream `pyproject.toml`.

### Source
- Bumps `version` to `0.2.0`; `sha256` taken from the GitHub release tag archive
  (`31e2a9845a5afc3bae7e1b6d1888c71827ee5b6fe83fd946097b155603dd34ad`).
- Points `source.url`/`home`/`dev_url` at `serapeum-org/Digital-Earth` (the repository was transferred there;
  the old `MAfarrag/...` URLs redirect). `doc_url` now points at the live docs site.
- Resets `build.number` to `0`.

### Requirements (aligned to upstream `pyproject.toml`)
- `python >=3.11` (upstream `requires-python = ">=3.11,<4"`).
- `numpy >=2.0.0`, `geopandas >=1.1.3`, `cleopatra >=0.15.0`, `pyramids >=0.27.0`, `loguru >=0.7.3`.
- Adds `pyyaml >=6.0` (new runtime dependency).
- Drops `geoplot` from `run` — it is now an **optional** extra upstream (`[project.optional-dependencies]`),
  not a runtime dependency.
- Drops the explicit `gdal` pin — digitalearth does not import `osgeo` directly; native GDAL is pulled in
  transitively via `pyramids`, matching upstream's deliberate omission of GDAL from runtime deps.
- Host now lists the build backend (`setuptools >=80.0.0`, `wheel`, `pip`) for `--no-build-isolation`.

### Tests
- Adds submodule imports (`digitalearth.scene`, `digitalearth.autostyle`) and `commands: pip check` plus
  `digitalearth --help` to exercise the new `digitalearth` console entry point
  (`[project.scripts] digitalearth = "digitalearth.cli:main"`).

Checklist:

- [x] Bumped the version and reset the build number to 0.
- [x] `sha256` matches the upstream release tag archive.
- [x] Dependencies aligned with the upstream `pyproject.toml`.
- [x] License file (`LICENSE.md`) is still packaged.
- [ ] Re-rendered with the latest conda-smithy (no build-matrix change in this PR; will run
      `@conda-forge-admin, please rerender` if CI requests it).