### PR TITLE
Update to 0.5.0 and add digitalearth-3d output

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "digitalearth" %}
-{% set version = "0.4.0" %}
+{% set version = "0.5.0" %}
 {% set python_min = "3.11" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/serapeum-org/Digital-Earth/archive/{{ version }}.tar.gz
-  sha256: 7739d235473b7d85eb8b799ed21163afb1d13f0cb0b169955c0f86d9de1240be
+  sha256: 1d348c32d831da41c0e4843812ef292781242dfb1b6e95b0104e0707ed7e7def
 
 build:
   number: 0
@@ -26,7 +26,7 @@ requirements:
     - numpy >=2.0.0
     - geopandas >=1.1.3
     - cleopatra >=0.17.0
-    - pyramids >=0.31.0,<0.32
+    - pyramids >=0.32.0
     - loguru >=0.7.3
     - pyyaml >=6.0
 
@@ -41,6 +41,28 @@ test:
   commands:
     - pip check
     - digitalearth --help
+
+outputs:
+  - name: {{ name }}
+
+  - name: {{ name }}-3d
+    build:
+      noarch: python
+    requirements:
+      run:
+        - {{ pin_subpackage(name, exact=True) }}
+        # mirrors the PyPI ``digitalearth[3d]`` extra: the PyVista true-3D tier
+        # (Scene3D) plus the textured-globe and animation backends.
+        - pyvista >=0.48
+        - trame >=3.13
+        - trame-vtk >=2.8
+        - trame-vuetify >=2.7
+        - geovista >=0.5.3
+        - imageio >=2.34
+        - imageio-ffmpeg >=0.5
+    test:
+      imports:
+        - digitalearth
 
 about:
   home: https://github.com/serapeum-org/Digital-Earth

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: python -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:


### PR DESCRIPTION
Bumps `digitalearth` to **0.5.0** and adds a new `digitalearth-3d` output.

### Changes
- `version`: `0.4.0` → `0.5.0`; `sha256` updated for the 0.5.0 archive.
- `pyramids`: `>=0.31.0,<0.32` → `>=0.32.0`. The `<0.32` cap is dropped because 0.5.0 moved the
  Natural-Earth helpers to `cleopatra.reference` (`from cleopatra.reference import natural_earth`), so it no
  longer needs the removed `pyramids.basemap.natural_earth` and is compatible with pyramids 0.32.x.
- New **`digitalearth-3d`** output — a metapackage mirroring the PyPI `digitalearth[3d]` extra (the PyVista
  true-3D `Scene3D` tier): `pyvista`, `trame`, `trame-vtk`, `trame-vuetify`, `geovista`, `imageio`,
  `imageio-ffmpeg`. All are available on conda-forge.

The output-name mapping (`digitalearth` → `digitalearth-3d`) is registered via
conda-forge/admin-requests#2142, which should merge before this is merged so the upload is authorized.

### Checklist
- [x] Used a personal fork of the feedstock to propose changes.
- [x] Bumped the build number to 0 (new version).
- [x] All dependencies are available on conda-forge.